### PR TITLE
morgan 및 winston 패키지 이용 log 설정

### DIFF
--- a/.circleci/.hello-build
+++ b/.circleci/.hello-build
@@ -1,9 +1,0 @@
-version: 2.1
-
-orbs:
-    hello: circleci/hello-build@0.0.7 # uses the circleci/buildpack-deps Docker image
-
-workflows:
-    "Hello Workflow":
-        jobs:
-          - hello/hello-build

--- a/app.js
+++ b/app.js
@@ -5,7 +5,8 @@ const path = require('path');
 // cookie-parser: 접속한 클라이언트의 쿠키 정보에 접근하기 위한 모듈
 const cookieParser = require('cookie-parser');
 // morgan : 클라이언트의 HTTP 요청 정보를 로깅하기 위한 모듈
-const logger = require('morgan');
+const morgan = require('morgan');
+const {stream} = require('./config/winston');
 // eslint-disable-next-line no-unused-vars
 const db = require('./db/db');
 
@@ -24,7 +25,7 @@ app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
 app.engine('html', require('ejs').renderFile);
 
-app.use(logger('dev'));
+app.use(morgan('combined', {stream}));
 app.use(express.json());
 app.use(express.urlencoded({extended: false}));
 app.use(cookieParser());

--- a/config/winston.js
+++ b/config/winston.js
@@ -1,0 +1,32 @@
+const fs =require('fs');
+const winston = require('winston');
+
+const logDir = __dirname + '/../logs';
+
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir);
+}
+
+const infoTransport = new winston.transports.File({
+  filename: 'info.log',
+  dirname: logDir,
+  level: 'info',
+});
+
+const errorTransport = new winston.transports.File({
+  filename: 'error.log',
+  dirname: logDir,
+  level: 'error',
+});
+
+const logger = winston.createLogger({
+  transports: [infoTransport, errorTransport],
+});
+
+const stream = {
+  write: (message) => {
+    logger.info(message);
+  },
+};
+
+module.exports = {logger, stream};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "morgan": "~1.9.1",
     "node": "^12.4.0",
     "pug": "^2.0.4",
-    "puppeteer": "^1.18.1"
+    "puppeteer": "^1.18.1",
+    "winston": "^3.2.1",
+    "winston-daily-rotate-file": "^3.9.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
## .circle/.hello-build :: ci 붙일 때 test 했던 파일 삭제. 
* 당연히 참인 명제

## package.json :: winston, winston-daily-rotate-file 패키지 추가. 
* winston은 로그를 남기는 본체고, winston-daily-rotate-file은 1일 단위로 로그를 쌓도록 관리해준다.
* winston은 가장 많이 사용하는 js 로그 모듈 이다

## app.js :: morgan 을 dev 설정에서 combined 로 변경
* morgan 은 아래와 같은 여러 종류의 preset 을 가지고 있습니다.

~~~
combined 
[
:remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"]
common 
[
:remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length]]
dev 
[
:method :url :status :response-time ms - :res[content-length]]
short
[
:remote-addr :remote-user :method :url HTTP/:http-version :status :res[content-length] - :response-time ms]
tiny
[
:method :url :status :res[content-length] - :response-time ms]
~~~

좀 더 자세한 정보를 출력하기 위해 combined로 변경 해줍니다 (보통 combined, common 사용)

## app.js :: log를 winston.js 로 보내기
* app.js 에서 morgan 을 이용해 request, reponse 의 log 들을 winston 을 이용해 console 출력 or file 출력 해야 해서

## winston.js :: winston을 이용 log를 file에 저장
* winston 객체를 이용해 어느 레벨(info, warn,debug 등등 )들을 어디에(console, db , file) 얼마나( 하루 최대 100 mb or 14일 동안만 저장 ) 등을 설정 할 수 있다. 